### PR TITLE
sink: attempt to make image tag unique per push

### DIFF
--- a/jobs/scripts/sink-clustered-deployment/sink-clustered-deployment.sh
+++ b/jobs/scripts/sink-clustered-deployment/sink-clustered-deployment.sh
@@ -68,6 +68,12 @@ if [ -n "${ghprbPullId}" ]; then
 	fi
 
 	CI_IMG_TAG="ci-k8s-${KUBE_VERSION}-pr${ghprbPullId}"
+	# if the sha1 hash is provided, we will try to append a short form of it to
+	# the tag to make the image unique to each "push" of the PR.
+	shortsha="${sha1:0:8}"
+	if [ -n "${shortsha}" ]; then
+		CI_IMG_TAG="${CI_IMG_TAG}-${shortsha}"
+	fi
 fi
 
 CI_IMG_OP="${CI_IMG_REGISTRY}/sink/samba-operator:${CI_IMG_TAG}"


### PR DESCRIPTION
According to the jenkins doc [1] I found the environment variable `sha1` should be set. This patch uses a shortened version to add to the tag when possible so that test runs on the same PR but different commits (pushes) done before the first test run are less likely to interfere with each other.

[1] https://plugins.jenkins.io/ghprb/