### PR TITLE
jobs: Update sink job to pass `$sha1`

### DIFF
--- a/jobs/sink-clustered-deployment.yml
+++ b/jobs/sink-clustered-deployment.yml
@@ -63,7 +63,7 @@
 
     builders:
     - shell: !include-raw-escape: scripts/common/get-node.sh
-    - shell: jobs/scripts/common/bootstrap.sh $WORKSPACE/jobs/scripts/sink-clustered-deployment/sink-clustered-deployment.sh "ghprbPullId=$ghprbPullId ghprbTargetBranch=$ghprbTargetBranch IMG_REGISTRY_AUTH_USR=$IMG_REGISTRY_AUTH_USR IMG_REGISTRY_AUTH_PASSWD=$IMG_REGISTRY_AUTH_PASSWD KUBE_VERSION=$KUBE_VERSION ROOK_VERSION=$ROOK_VERSION"
+    - shell: jobs/scripts/common/bootstrap.sh $WORKSPACE/jobs/scripts/sink-clustered-deployment/sink-clustered-deployment.sh "ghprbPullId=$ghprbPullId ghprbTargetBranch=$ghprbTargetBranch sha1=$sha1 IMG_REGISTRY_AUTH_USR=$IMG_REGISTRY_AUTH_USR IMG_REGISTRY_AUTH_PASSWD=$IMG_REGISTRY_AUTH_PASSWD KUBE_VERSION=$KUBE_VERSION ROOK_VERSION=$ROOK_VERSION"
 
     publishers:
     - email-ext:


### PR DESCRIPTION
Previous commit 72240d5442626695c7f21d59784cf6166bacbf6d consumes `$sha1` inside the sink-clustered-deployment job script but it was never passed over from job definition itself.