### PR TITLE
sink: do not use sha1 values that are not hashes

### DIFF
--- a/jobs/scripts/sink-clustered-deployment/sink-clustered-deployment.sh
+++ b/jobs/scripts/sink-clustered-deployment/sink-clustered-deployment.sh
@@ -70,8 +70,8 @@ if [ -n "${ghprbPullId}" ]; then
 	CI_IMG_TAG="ci-k8s-${KUBE_VERSION}-pr${ghprbPullId}"
 	# if the sha1 hash is provided, we will try to append a short form of it to
 	# the tag to make the image unique to each "push" of the PR.
-	shortsha="${sha1:0:8}"
-	if [ -n "${shortsha}" ]; then
+	if [[ "$sha1" =~ ^[abcdef0-9]{4}[abcdef0-9]*$ ]]; then
+		shortsha="${sha1:0:8}"
 		CI_IMG_TAG="${CI_IMG_TAG}-${shortsha}"
 	fi
 fi

--- a/jobs/sink-clustered-deployment.yml
+++ b/jobs/sink-clustered-deployment.yml
@@ -63,7 +63,7 @@
 
     builders:
     - shell: !include-raw-escape: scripts/common/get-node.sh
-    - shell: jobs/scripts/common/bootstrap.sh $WORKSPACE/jobs/scripts/sink-clustered-deployment/sink-clustered-deployment.sh "ghprbPullId=$ghprbPullId ghprbTargetBranch=$ghprbTargetBranch sha1=$sha1 IMG_REGISTRY_AUTH_USR=$IMG_REGISTRY_AUTH_USR IMG_REGISTRY_AUTH_PASSWD=$IMG_REGISTRY_AUTH_PASSWD KUBE_VERSION=$KUBE_VERSION ROOK_VERSION=$ROOK_VERSION"
+    - shell: jobs/scripts/common/bootstrap.sh $WORKSPACE/jobs/scripts/sink-clustered-deployment/sink-clustered-deployment.sh "ghprbPullId=$ghprbPullId ghprbTargetBranch=$ghprbTargetBranch sha1=$ghprbActualCommit IMG_REGISTRY_AUTH_USR=$IMG_REGISTRY_AUTH_USR IMG_REGISTRY_AUTH_PASSWD=$IMG_REGISTRY_AUTH_PASSWD KUBE_VERSION=$KUBE_VERSION ROOK_VERSION=$ROOK_VERSION"
 
     publishers:
     - email-ext:


### PR DESCRIPTION
This fixes a problem with the previous commit where the sha1 environment variable is apparently being set to a branch name and not a sha1 (hex) hash digest value. This change skips using the sha1 as a unique id if the value doesn't appear to be a hex value.