### PR TITLE
jobs/scripts: Pre-fetch vagrant boxes for CentOS Stream

### DIFF
--- a/jobs/scripts/nightly-samba-builds/nightly-samba-builds.sh
+++ b/jobs/scripts/nightly-samba-builds/nightly-samba-builds.sh
@@ -94,16 +94,18 @@ then
 
 fi
 
-# Pre-fetch 9-stream vagrant libvirt box as it is not yet referenced from
-# app.vagrantup.com/boxes
-vagrant box add --provider libvirt --name centos/stream9 \
-	https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-Vagrant-9-20220808.1.x86_64.vagrant-libvirt.box
-
 if [[ "${PLATFORM}" = "fedora" ]]
 then
 	make "rpms.fedora" "vers=${VERSION}" "refspec=${SAMBA_BRANCH}"
 	make "test.rpms.fedora" "vers=${VERSION}" "refspec=${SAMBA_BRANCH}"
 else
+	# Pre-fetch vagrant libvirt boxes for CentOS Stream as latest versions
+	# are not yet referenced from app.vagrantup.com/boxes
+	vagrant box add --provider libvirt --name centos/stream8 \
+		https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-Vagrant-8-20230308.3.x86_64.vagrant-libvirt.box
+	vagrant box add --provider libvirt --name centos/stream9 \
+		https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-Vagrant-9-20230313.0.x86_64.vagrant-libvirt.box
+
 	make "rpms.${PLATFORM}${VERSION}" "refspec=${SAMBA_BRANCH}"
 	make "test.rpms.${PLATFORM}${VERSION}" "refspec=${SAMBA_BRANCH}"
 fi


### PR DESCRIPTION
We are facing the below signature error as mentioned in the [bug #1918777](https://bugzilla.redhat.com/show_bug.cgi?id=1918777) while executing `dnf update`:

```
Running transaction check
error: /var/cache/dnf/baseos-00fe51d07def85f0/packages/NetworkManager-1.40.16-1.el8.x86_64.rpm: signature hdr data: BAD, no. of bytes(21364) out of range
The downloaded packages were saved in cache until the next successful transaction.
You can remove cached packages by executing 'dnf clean packages'.
Error: error reading package header: '/var/cache/dnf/baseos-00fe51d07def85f0/packages/NetworkManager-1.40.16-1.el8.x86_64.rpm'
```

Due to the presence of an old pre-installed version of RPM in vagrant box for CentOS Stream 8 we were unable to perform a complete system update. Therefore make sure that we keep up with the recent versions of libvirt vagrant boxes for CentOS Stream.