### PR TITLE
sink: Run against Kubernetes v1.27

### DIFF
--- a/jobs/sink-clustered-deployment.yml
+++ b/jobs/sink-clustered-deployment.yml
@@ -1,9 +1,9 @@
 - project:
     name: samba_sink_mini_k8s
     k8s_version:
-      - '1.24'
       - '1.25'
       - '1.26'
+      - '1.27'
     jobs:
       - 'samba_sink-mini-k8s-{k8s_version}-clustered'
 


### PR DESCRIPTION
This also removes support for testing againt v1.24.

Depends on #10 