### PR TITLE
deploy/Dockerfile: Install at least Python 3.8

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/centos/centos:stream
 
 RUN true \
- && dnf -y install python3-pip \
+ && dnf -y install python3.8 \
  && pip3 install jenkins-job-builder \
  && dnf -y clean all \
  && true


### PR DESCRIPTION
Installing python3-pip used to pull in already EOL'ed Python version 3.6. With more recent versions of _**jenkins-job-builde**r_ Python 3.7 is a minimum requirement due to which we started observing the following failure:

```
Traceback (most recent call last):
  File "/usr/local/bin/jenkins-jobs", line 7, in <module>
    from jenkins_jobs.cli.entry import main
  File "/usr/local/lib/python3.6/site-packages/jenkins_jobs/cli/entry.py", line 25, in <module>
    from jenkins_jobs.errors import JenkinsJobsException
  File "/usr/local/lib/python3.6/site-packages/jenkins_jobs/errors.py", line 4, in <module>
    from dataclasses import dataclass
ModuleNotFoundError: No module named 'dataclasses'
```

**_jenkins-job-builder_** failed to check installed Python version resulting in the above run time error for which a [task](https://storyboard.openstack.org/#!/story/2010716) has been created to work on a fix. However Python 3.7 is due EOL soon(around June 2023). Therefore install Python 3.8 explicitly by default.