### PR TITLE
jobs/scripts: Avoid pre-fetching vagrant boxes

### DIFF
--- a/jobs/scripts/gluster-integration/gluster-integration.sh
+++ b/jobs/scripts/gluster-integration/gluster-integration.sh
@@ -94,14 +94,6 @@ systemctl start libvirtd
 # environment in case something goes wrong.
 virsh capabilities
 
-# Prefetch the centos/stream8 vagrant box as latest version is not yet
-# referenced from app.vagrantup.com/boxes.
-# (The echo is becuase of "set -e" and that an existing box will cause
-#  vagrant to return non-zero.)
-vagrant box add --provider libvirt --name centos/stream8 \
-	https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-Vagrant-8-20230308.3.x86_64.vagrant-libvirt.box \
-	|| echo "Warning: the vagrant box may already exist OR an error occured"
-
 #
 # === Phase 3 ============================================================
 #

--- a/jobs/scripts/nightly-samba-builds/nightly-samba-builds.sh
+++ b/jobs/scripts/nightly-samba-builds/nightly-samba-builds.sh
@@ -99,13 +99,6 @@ then
 	make "rpms.fedora" "vers=${VERSION}" "refspec=${SAMBA_BRANCH}"
 	make "test.rpms.fedora" "vers=${VERSION}" "refspec=${SAMBA_BRANCH}"
 else
-	# Pre-fetch vagrant libvirt boxes for CentOS Stream as latest versions
-	# are not yet referenced from app.vagrantup.com/boxes
-	vagrant box add --provider libvirt --name centos/stream8 \
-		https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-Vagrant-8-20230308.3.x86_64.vagrant-libvirt.box
-	vagrant box add --provider libvirt --name centos/stream9 \
-		https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-Vagrant-9-20230313.0.x86_64.vagrant-libvirt.box
-
 	make "rpms.${PLATFORM}${VERSION}" "refspec=${SAMBA_BRANCH}"
 	make "test.rpms.${PLATFORM}${VERSION}" "refspec=${SAMBA_BRANCH}"
 fi


### PR DESCRIPTION
Given the fact that latest versions of vagrant libvirt boxes for CentOS Stream not getting referenced frequently we switch to generic boxes.