### PR TITLE
get-node.sh: Make sure that `~/.config` exists

### DIFF
--- a/jobs/scripts/common/get-node.sh
+++ b/jobs/scripts/common/get-node.sh
@@ -3,6 +3,8 @@
 
 set +x
 
+mkdir -p ~/.config
+
 cat > ~/.config/duffy <<EOF
 client:
   url: https://duffy.ci.centos.org/api/v1


### PR DESCRIPTION
With recent update to cico-workspace container image current assumption that `~/.config` existed no longer holds true. Therefore we explicitly make sure that it exists before creating `~/.config/duffy`.

Note: Fix was manually verified at jenkins instance.