### PR TITLE
build-rpms: Replace fedora v36 builds with v38

### DIFF
--- a/jobs/nightly-samba-builds.yml
+++ b/jobs/nightly-samba-builds.yml
@@ -3,7 +3,7 @@
     os_version:
       - 'centos8'
       - 'centos9'
-      - 'fedora36'
+      - 'fedora38'
       - 'fedora37'
     samba_branch:
       - 'master'


### PR DESCRIPTION
Fedora 36 reached EOL.