### PR TITLE
Install podman and other recent requirements

### DIFF
--- a/jobs/scripts/nightly-samba-builds/nightly-samba-builds.sh
+++ b/jobs/scripts/nightly-samba-builds/nightly-samba-builds.sh
@@ -30,7 +30,8 @@ set -x
 # epel is needed to get more up-to-date versions of mock and ansible.
 dnf -y install epel-release epel-next-release
 dnf -y install git make rpm-build mock createrepo_c \
-	ansible-core ansible-collection-ansible-posix
+	ansible-core ansible-collection-ansible-posix \
+	ansible-collection-containers-podman podman jq
 
 # Install QEMU-KVM and Libvirt packages
 dnf -y install qemu-kvm qemu-img libvirt libvirt-devel


### PR DESCRIPTION
To test installation of rpms in a container we require corresponding ansible collection and `podman` itself. In addition to that `jq` has become a requirement to parse JSON response in detecting latest Ceph development repo URLs.