### PR TITLE
Use explicit timeout as workaround for python-jenkins

### DIFF
--- a/deploy/jenkins.conf
+++ b/deploy/jenkins.conf
@@ -10,3 +10,4 @@ allow_duplicates=False
 user=sambabot-admin-edit-view
 password=JENKINS_API_KEY
 url=https://jenkins-samba.apps.ocp.cloud.ci.centos.org/
+timeout=60


### PR DESCRIPTION
As mentioned in the bug reported against python-jenkins we could specify a timeout value in order to workaround the compatibility issue with updated urllib3 dependency. More details at [launchpad #2018567](https://bugs.launchpad.net/python-jenkins/+bug/2018567).

