### PR TITLE
jobs/scripts: Fix installation of `netaddr` python module

### DIFF
--- a/jobs/scripts/gluster-integration/gluster-integration.sh
+++ b/jobs/scripts/gluster-integration/gluster-integration.sh
@@ -70,7 +70,7 @@ fi
 dnf -y install epel-release epel-next-release
 
 dnf -y install make ansible-core ansible-collection-ansible-posix \
-               ansible-collection-ansible-utils python3-netaddr
+               ansible-collection-ansible-utils python3.11-netaddr
 
 # Install QEMU-KVM and Libvirt packages
 dnf -y install qemu-kvm qemu-img libvirt libvirt-devel


### PR DESCRIPTION
Ansible is built with Python 3.11 and thus required modules are searched from _/usr/lib/python3.11/site-packages_. Therefore force a version specific install of `netaddr` python module.