### PR TITLE
jobs/scripts: Move skipping of scheduled run for sit-environment

### DIFF
--- a/jobs/scripts/gluster-integration/gluster-integration.sh
+++ b/jobs/scripts/gluster-integration/gluster-integration.sh
@@ -37,9 +37,6 @@ if [ "${GIT_TARGET_REPO}" = "sit-test-cases" ]; then
 	if [ -n "${ghprbPullId}" ]; then
 		# Just invoke "make test" with the corresponding parameters.
 		TEST_EXTRA_VARS="test_repo=${GIT_TARGET_REPO_URL} test_repo_pr=${ghprbPullId}"
-	else
-		echo "Skipping scheduled run"
-		exit 0
 	fi
 else
 	if [ -n "${ghprbPullId}" ]; then
@@ -54,6 +51,9 @@ else
 			echo "Unable to automatically rebase to branch '${ghprbTargetBranch}'. Please rebase your PR!"
 			exit 1
 		fi
+	else
+		echo "Skipping scheduled run"
+		exit 0
 	fi
 fi
 


### PR DESCRIPTION
For every pull request on _sit-test-cases_ repository we run the entire test suite. We used to skip the scheduled nightly run of entire integration test suite for _sit-test-cases_ repository. Thus it is better to always associate entire test run with _sit-test-cases_ repository by moving the skip part to _sit-environment_ repository.

In short, [samba_gluster-integration-test-cases](https://jenkins-samba.apps.ocp.cloud.ci.centos.org/job/samba_gluster-integration-test-cases/) job from jenkins will always run the full test suite for every pull request and nightly schedule.