### PR TITLE
fs-integration: Remove group installation of development tools

### DIFF
--- a/jobs/scripts/fs-integration/fs-integration.sh
+++ b/jobs/scripts/fs-integration/fs-integration.sh
@@ -79,9 +79,6 @@ dnf -y install make ansible-core ansible-collection-ansible-posix \
 # Install QEMU-KVM and Libvirt packages
 dnf -y install qemu-kvm qemu-img libvirt libvirt-devel
 
-# "Development Tools" are needed to run "vagrant plugin install"
-dnf -y group install "Development Tools"
-
 # Use Fedora COPR maintained builds for vagrant and its dependencies
 # including libvirt plugin instead of upstream version with added
 # difficulty of rebuilding krb5 and libssh libraries.


### PR DESCRIPTION
We explicitly install vagrant-libvirt and no longer perform internal installation using `vargant` command line.

depends on #26 