### PR TITLE
sink: Update jobs to reflect kubernetes v1.28 release

### DIFF
--- a/jobs/sink-clustered-deployment.yml
+++ b/jobs/sink-clustered-deployment.yml
@@ -1,8 +1,8 @@
 - project:
     name: samba_sink_mini_k8s
     k8s_version:
-      - '1.25'
       - '1.26'
+      - '1.27'
       - 'latest'
     jobs:
       - 'samba_sink-mini-k8s-{k8s_version}-clustered'


### PR DESCRIPTION
With v1.28 [released](https://github.com/kubernetes/kubernetes/releases/tag/v1.28.0) we could replace the current job for running against kubernetes v1.25 with v1.27.