### PR TITLE
build-rpms: Replace v4.17 jobs with v4.19

### DIFF
--- a/jobs/nightly-samba-builds.yml
+++ b/jobs/nightly-samba-builds.yml
@@ -8,7 +8,7 @@
     samba_branch:
       - 'master'
       - 'v4-18-test'
-      - 'v4-17-test'
+      - 'v4-19-test'
     jobs:
       - 'samba_build-rpms-{os_version}-{samba_branch}'
 


### PR DESCRIPTION
depends on https://github.com/samba-in-kubernetes/samba-build/pull/24