### PR TITLE
fs-integration: Always run sanity test for sit-environment

### DIFF
--- a/jobs/scripts/fs-integration/fs-integration.sh
+++ b/jobs/scripts/fs-integration/fs-integration.sh
@@ -44,9 +44,6 @@ if [ "${GIT_TARGET_REPO}" = "sit-test-cases" ]; then
 	fi
 else
 	if [ -n "${ghprbPullId}" ]; then
-		# Run sanity tests only for pull requests on sit-environment
-		TEST_EXTRA_VARS="${TEST_EXTRA_VARS} test_sanity_only=1"
-
 		git fetch origin "pull/${ghprbPullId}/head:pr_${ghprbPullId}"
 		git checkout "pr_${ghprbPullId}"
 
@@ -55,10 +52,9 @@ else
 			echo "Unable to automatically rebase to branch '${ghprbTargetBranch}'. Please rebase your PR!"
 			exit 1
 		fi
-	else
-		echo "Skipping scheduled run"
-		exit 0
 	fi
+
+	TEST_EXTRA_VARS="${TEST_EXTRA_VARS} test_sanity_only=1"
 fi
 
 #


### PR DESCRIPTION
Nightly scheduled run against sit-environment repository used to skip the execution of testsuite. Instead we could run the basic sanity as we do for pull requests on the repository.