### PR TITLE
fs-integration: Fix `set` bash builtin option

### DIFF
--- a/jobs/scripts/fs-integration/fs-integration.sh
+++ b/jobs/scripts/fs-integration/fs-integration.sh
@@ -95,7 +95,7 @@ virsh capabilities
 # run the tests
 #
 
-set +x
+set +e
 
 EXTRA_VARS="${TEST_EXTRA_VARS}" make "${TEST_TARGET}"
 ret=$?


### PR DESCRIPTION
We wanted to always have the statedump tarball created irrespective of the test run exit status. But the `set` bash builtin option was wrongly configured with 'x' and not 'e'. Replace '+x' with '+e' to achieve the real goal of always creating the compressed tarball of statedump directory.

See [manual](https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html) for more details.