### PR TITLE
fs-integration: Avoid running full test suite always for GlusterFS

### DIFF
--- a/jobs/fs-integration.yml
+++ b/jobs/fs-integration.yml
@@ -48,6 +48,11 @@
     - timed: "H 2 * * *"
     - github-pull-request:
         trigger-phrase: '/(re)?test ((all)|(centos-ci/({file_system})?))'
+        white-list-labels:
+        - !j2: |
+            {% if (git_repo == 'test-cases') and (file_system == 'glusterfs') -%}
+              centos-ci/glusterfs
+            {%- endif %}
         admin-list:
         - obnoxxx
         - gd


### PR DESCRIPTION
Hereafter require a GitHub label(`centos-ci/glusterfs`) on pull requests against [sit-test-cases](https://github.com/samba-in-kubernetes/sit-test-cases) repository to trigger full test suite run for GlusterFS.

_Please note that in addition to setting the required label corresponding keywords are to be made as GitHub comment to trigger the job. In this case a comment in the form `/test centos-ci/glusterfs` or `/retest centos-ci/glusterfs` is expected after **centos-ci/glusterfs** label is set on the pull request. This extra step can't be avoided due to an open issue https://github.com/jenkinsci/ghprb-plugin/issues/496_