### PR TITLE
sink: Make pull request runs limited to latest k8s version

### DIFF
--- a/jobs/sink-clustered-deployment.yml
+++ b/jobs/sink-clustered-deployment.yml
@@ -46,20 +46,22 @@
         days-to-keep: 7
         artifacts-days-to-keep: 7
 
-    triggers:
-    - timed: "H 2 * * *"
-    - github-pull-request:
-        trigger-phrase: '/(re)?test ((all)|(centos-ci/sink-clustered/mini-k8s-({k8s_version})?))'
-        admin-list:
-          - obnoxxx
-          - phlogistonjohn
-          - gd
-          - spuiuk
-          - raghavendra-talur
-          - synarete
-          - anoopcs9
-        cron: H/5 * * * *
-        status-context: 'centos-ci/sink-clustered/mini-k8s-{k8s_version}'
+    triggers: !j2-yaml: |
+      {% if k8s_version == 'latest' %}
+        - github-pull-request:
+            trigger-phrase: '/(re)?test ((all)|(centos-ci/sink-clustered/mini-k8s-(latest)?))'
+            admin-list:
+              - obnoxxx
+              - phlogistonjohn
+              - gd
+              - spuiuk
+              - raghavendra-talur
+              - synarete
+              - anoopcs9
+            cron: H/5 * * * *
+            status-context: 'centos-ci/sink-clustered/mini-k8s-{k8s_version}'
+      {% endif %}
+        - timed: "H 2 * * *"
 
     builders:
     - shell: !include-raw-escape: scripts/common/get-node.sh


### PR DESCRIPTION
Instead of triggering runs against recent 3 kubernetes version for every PR on [samba-operator](https://github.com/samba-in-kubernetes/samba-operator) repository modify job definition to only trigger the run against latest kubernetes version.