### PR TITLE
build-rpms: Replace fedora v37 builds with v39

### DIFF
--- a/jobs/nightly-samba-builds.yml
+++ b/jobs/nightly-samba-builds.yml
@@ -4,7 +4,7 @@
       - 'centos8'
       - 'centos9'
       - 'fedora38'
-      - 'fedora37'
+      - 'fedora39'
     samba_branch:
       - 'master'
       - 'v4-18-test'


### PR DESCRIPTION
Fedora 37 reached EOL.