### PR TITLE
jobs: Avoid displaying expanded commands in execution

### DIFF
--- a/jobs/fs-integration.yml
+++ b/jobs/fs-integration.yml
@@ -69,7 +69,9 @@
 
     builders:
     - shell: !include-raw-escape: scripts/common/get-node.sh
-    - shell: jobs/scripts/common/bootstrap.sh $WORKSPACE/jobs/scripts/fs-integration/fs-integration.sh "ghprbPullId=$ghprbPullId ghprbTargetBranch=$ghprbTargetBranch CENTOS_VERSION=$CENTOS_VERSION FILE_SYSTEM=$FILE_SYSTEM GIT_REPO=$GIT_REPO"
+    - shell: |
+        #!/bin/bash
+        jobs/scripts/common/bootstrap.sh $WORKSPACE/jobs/scripts/fs-integration/fs-integration.sh "ghprbPullId=$ghprbPullId ghprbTargetBranch=$ghprbTargetBranch CENTOS_VERSION=$CENTOS_VERSION FILE_SYSTEM=$FILE_SYSTEM GIT_REPO=$GIT_REPO"
 
     publishers:
     - email-ext:

--- a/jobs/nightly-samba-builds.yml
+++ b/jobs/nightly-samba-builds.yml
@@ -69,7 +69,9 @@
     builders:
     - shell: !include-raw-escape: scripts/common/get-node.sh
     - shell: !include-raw-escape: scripts/common/scp.sh
-    - shell: jobs/scripts/common/bootstrap.sh $WORKSPACE/jobs/scripts/nightly-samba-builds/nightly-samba-builds.sh "ghprbPullId=$ghprbPullId ghprbTargetBranch=$ghprbTargetBranch CENTOS_VERSION=$CENTOS_VERSION OS_VERSION=$OS_VERSION SAMBA_BRANCH=$SAMBA_BRANCH"
+    - shell: |
+        #!/bin/bash
+        jobs/scripts/common/bootstrap.sh $WORKSPACE/jobs/scripts/nightly-samba-builds/nightly-samba-builds.sh "ghprbPullId=$ghprbPullId ghprbTargetBranch=$ghprbTargetBranch CENTOS_VERSION=$CENTOS_VERSION OS_VERSION=$OS_VERSION SAMBA_BRANCH=$SAMBA_BRANCH"
 
     publishers:
     - email-ext:

--- a/jobs/scripts/fs-integration/fs-integration.sh
+++ b/jobs/scripts/fs-integration/fs-integration.sh
@@ -16,9 +16,6 @@ TEST_TARGET="test"
 # if anything fails, we'll abort
 set -e
 
-# TODO: disable debugging
-set -x
-
 #
 # === Phase 1 ============================================================
 #

--- a/jobs/sink-clustered-deployment.yml
+++ b/jobs/sink-clustered-deployment.yml
@@ -65,7 +65,9 @@
 
     builders:
     - shell: !include-raw-escape: scripts/common/get-node.sh
-    - shell: jobs/scripts/common/bootstrap.sh $WORKSPACE/jobs/scripts/sink-clustered-deployment/sink-clustered-deployment.sh "ghprbPullId=$ghprbPullId ghprbTargetBranch=$ghprbTargetBranch sha1=$ghprbActualCommit IMG_REGISTRY_AUTH_USR=$IMG_REGISTRY_AUTH_USR IMG_REGISTRY_AUTH_PASSWD=$IMG_REGISTRY_AUTH_PASSWD KUBE_VERSION=$KUBE_VERSION ROOK_VERSION=$ROOK_VERSION"
+    - shell: |
+        #!/bin/bash
+        jobs/scripts/common/bootstrap.sh $WORKSPACE/jobs/scripts/sink-clustered-deployment/sink-clustered-deployment.sh "ghprbPullId=$ghprbPullId ghprbTargetBranch=$ghprbTargetBranch sha1=$ghprbActualCommit IMG_REGISTRY_AUTH_USR=$IMG_REGISTRY_AUTH_USR IMG_REGISTRY_AUTH_PASSWD=$IMG_REGISTRY_AUTH_PASSWD KUBE_VERSION=$KUBE_VERSION ROOK_VERSION=$ROOK_VERSION"
 
     publishers:
     - email-ext:


### PR DESCRIPTION
* `-x` was added in initial stages when we were keen on looking into failures during various steps of command execution. Over time it has become stable and we no longer require to list every command that is being executed in the console output. In fact this was already a TODO and can be fixed now.

* Be explicit about the shell command options so that `-x` is not included by default.