### PR TITLE
sink: Update jobs to reflect kubernetes v1.29 release

### DIFF
--- a/jobs/sink-clustered-deployment.yml
+++ b/jobs/sink-clustered-deployment.yml
@@ -1,7 +1,7 @@
 - project:
     name: samba_sink_mini_k8s
     k8s_version:
-      - '1.26'
+      - '1.28'
       - '1.27'
       - 'latest'
     jobs:


### PR DESCRIPTION
With [v1.29]( https://github.com/kubernetes/kubernetes/releases/tag/v1.29.0) released we could replace the current job for running against kubernetes v1.26 with v1.28.