### PR TITLE
fs-integration: Install python modules using pip

### DIFF
--- a/jobs/scripts/fs-integration/fs-integration.sh
+++ b/jobs/scripts/fs-integration/fs-integration.sh
@@ -64,7 +64,11 @@ fi
 dnf -y install epel-release epel-next-release
 
 dnf -y install make ansible-core ansible-collection-ansible-posix \
-               ansible-collection-ansible-utils python3.11-netaddr
+               ansible-collection-ansible-utils
+
+# Install python modules using pip for ansible built with python 3.12
+dnf -y install python3.12-pip
+pip3.12 install netaddr
 
 # Install QEMU-KVM and Libvirt packages
 dnf -y install qemu-kvm qemu-img libvirt libvirt-devel


### PR DESCRIPTION
Very recently on CentOS Stream 8 ansible version got updated to _v2.16.3_ built with Python 3.12. Due to unavailability of minimum required python 3.12 modules playbook execution started to fail as follows:

> An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ansible.errors.AnsibleFilterError: The ipaddr filter requires python's netaddr be installed on the ansible controller
fatal: [localhost]: FAILED! => {"changed": false, "msg": "AnsibleFilterError: The ipaddr filter requires python's netaddr be installed on the ansible controller"}

Therefore switch python module installation from RPMs to pip.