### PR TITLE
build-rpms: Remove CentOS 8 based builds

### DIFF
--- a/jobs/nightly-samba-builds.yml
+++ b/jobs/nightly-samba-builds.yml
@@ -1,7 +1,6 @@
 - project:
     name: samba_nightly-rpm-builds
     os_version:
-      - 'centos8'
       - 'centos9'
       - 'fedora40'
       - 'fedora39'


### PR DESCRIPTION
CentOS Stream 8 reached EOL on 31st May 2024.