### PR TITLE
fs-integration: install samba-vfs-cephfs

### DIFF
--- a/jobs/scripts/fs-integration/fs-integration.sh
+++ b/jobs/scripts/fs-integration/fs-integration.sh
@@ -122,6 +122,11 @@ if [[ "${BACKEND}" =~ "gpfs" ]]; then
 	popd
 fi
 
+if  [[ "${BACKEND}" =~ "cephfs" ]]; then
+	# Download and install samba-vfs-cephfs for vfs_ceph_snapshots
+	dnf -y install samba-vfs-cephfs
+fi
+
 #
 # === Phase 3 ============================================================
 #


### PR DESCRIPTION
vfs_ceph_snapshots fails with
"Error loading module '/usr/lib64/samba/vfs/ceph_snapshots.so': /usr/lib64/samba/vfs/ceph_snapshots.so: cannot open shared object file: No such file or directory"
when samba-vfs-cephfs package is not installed.

Hence installing the same for ceph backend atop a kernel CephFS mounted share path.