### PR TITLE
build-rpms: Use common target to build rpms

### DIFF
--- a/jobs/scripts/nightly-samba-builds/nightly-samba-builds.sh
+++ b/jobs/scripts/nightly-samba-builds/nightly-samba-builds.sh
@@ -72,14 +72,8 @@ then
 
 fi
 
-if [[ "${PLATFORM}" = "fedora" ]]
-then
-	make "rpms.fedora" "vers=${VERSION}" "refspec=${SAMBA_BRANCH}"
-	make "test.rpms.fedora" "vers=${VERSION}" "refspec=${SAMBA_BRANCH}"
-else
-	make "rpms.${PLATFORM}${VERSION}" "refspec=${SAMBA_BRANCH}"
-	make "test.rpms.${PLATFORM}${VERSION}" "refspec=${SAMBA_BRANCH}"
-fi
+make "rpms.${PLATFORM}" "vers=${VERSION}" "refspec=${SAMBA_BRANCH}"
+make "test.rpms.${PLATFORM}" "vers=${VERSION}" "refspec=${SAMBA_BRANCH}"
 
 # Don't upload the artifacts if running on a PR.
 if [ -n "${ghprbPullId}" ]


### PR DESCRIPTION
With https://github.com/samba-in-kubernetes/samba-build/pull/48 we combine version specific build targets for CentOS using a general makefile rule.

depends on https://github.com/samba-in-kubernetes/samba-build/pull/48