### PR TITLE
fs-integration: Add cephfs variant to use `vfs_ceph_new`

### DIFF
--- a/jobs/fs-integration.yml
+++ b/jobs/fs-integration.yml
@@ -8,6 +8,7 @@
       - 'xfs'
       - 'cephfs'
       - 'cephfs.vfs'
+      - 'cephfs.vfs.new'
       - 'cephfs.mgr.vfs'
       - 'gpfs'
       - 'gpfs.vfs'


### PR DESCRIPTION
depends on https://github.com/samba-in-kubernetes/sit-environment/pull/116