### PR TITLE
fs-integraiton: Refresh the file system variants list

### DIFF
--- a/jobs/fs-integration.yml
+++ b/jobs/fs-integration.yml
@@ -7,10 +7,8 @@
       - 'glusterfs'
       - 'xfs'
       - 'cephfs'
-      - 'cephfs.vfs'
       - 'cephfs.mgr.vfs'
       - 'gpfs'
-      - 'gpfs.vfs'
       - 'gpfs.scale'
     jobs:
       - 'samba_{file_system}-integration-{git_repo}'

--- a/jobs/fs-integration.yml
+++ b/jobs/fs-integration.yml
@@ -7,7 +7,7 @@
       - 'glusterfs'
       - 'xfs'
       - 'cephfs'
-      - 'cephfs.mgr.vfs'
+      - 'cephfs.mgr'
       - 'gpfs'
       - 'gpfs.scale'
     jobs:


### PR DESCRIPTION
Optimizations included:
- `cephfs.vfs` configuration is grouped inside `cephfs`.
- `cephfs.mgr.vfs` can be just `cephfs.mgr`.

depends on https://github.com/samba-in-kubernetes/sit-environment/pull/117