### PR TITLE
build-rpms: Replace v4.19 jobs with v4.21

### DIFF
--- a/jobs/nightly-samba-builds.yml
+++ b/jobs/nightly-samba-builds.yml
@@ -7,7 +7,7 @@
     samba_branch:
       - 'master'
       - 'v4-20-test'
-      - 'v4-19-test'
+      - 'v4-21-test'
     jobs:
       - 'samba_build-rpms-{os_version}-{samba_branch}'
 


### PR DESCRIPTION
Samba [4.21.0](https://www.samba.org/samba/history/samba-4.21.0.html) GA.