### PR TITLE
sink: Update jobs to reflect kubernetes v1.32 release

### DIFF
--- a/jobs/sink-clustered-deployment.yml
+++ b/jobs/sink-clustered-deployment.yml
@@ -2,7 +2,7 @@
     name: samba_sink_mini_k8s
     k8s_version:
       - '1.30'
-      - '1.29'
+      - '1.31'
       - 'latest'
     jobs:
       - 'samba_sink-mini-k8s-{k8s_version}-clustered'


### PR DESCRIPTION
Kubernetes [v1.32](https://github.com/kubernetes/kubernetes/releases/tag/v1.32.0) GA.