### PR TITLE
build-containers: Enable aarch64 for default CentOS

### DIFF
--- a/jobs/nightly-samba-containers.yml
+++ b/jobs/nightly-samba-containers.yml
@@ -16,10 +16,6 @@
       # ceph development rpm builds are not available for fedora
       - os_name: 'fedora'
         package_source: 'devbuilds'
-      # resilient storage providing ctdb on centos is not available for aarch64
-      - os_name: 'centos'
-        os_arch: 'aarch64'
-        package_source: 'default'
     jobs:
       - 'samba_build-containers-{kind}-{package_source}-{os_name}-{os_arch}'
 


### PR DESCRIPTION
The previous requirement for resilientstorage repo is no longer true after https://github.com/samba-in-kubernetes/samba-container/pull/207. Remove the corresponding exclude from the job matrix.